### PR TITLE
fix: order confirmation emails sent after successful payment

### DIFF
--- a/Observer/SalesOrderPaymentPlaceStart.php
+++ b/Observer/SalesOrderPaymentPlaceStart.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Dintero\Checkout\Observer;
+
+use Dintero\Checkout\Model\Dintero as DinteroCheckout;
+
+class SalesOrderPaymentPlaceStart implements \Magento\Framework\Event\ObserverInterface
+{
+    /**
+     * Sales Order Payment Place Start Observer
+     *
+     * @param \Magento\Framework\Event\Observer $observer
+     */
+    public function execute(\Magento\Framework\Event\Observer $observer)
+    {
+        $payment = $observer['payment'];
+        if ($payment->getMethod() == DinteroCheckout::METHOD_CODE) {
+            $order = $payment->getOrder();
+            $order->setCanSendNewEmailFlag(false);
+            $order->setIsCustomerNotified(false);
+            $order->save();
+        }
+    }
+}

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+  <event name="sales_order_payment_place_start">
+    <observer name="Dintero_Checkout_Sales_Order_Payment_Place_Start" instance="Dintero\Checkout\Observer\SalesOrderPaymentPlaceStart" />
+  </event>
+</config>


### PR DESCRIPTION
As per default Magento 2 behavior, order confirmation emails are sent at order creation. This PR uses an observer to prevent sending the confirmation when _dintero_ payment method are used. Further it sends the order email after successful payment.

Further work before merging could be to add a user configuration switch, similar to this:
![image](https://user-images.githubusercontent.com/8796678/108321435-6fe8f980-71c4-11eb-8db3-eb0fc0266e09.png)
