### PR TITLE
Support branding for named payment profiles

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -390,11 +390,11 @@ class Config extends AbstractHelper
     public function getDefaultLogoUrl()
     {
         $baseUrl = Client::CHECKOUT_API_BASE_URL;
-        $pattern = '%s/branding/logos/visa_mastercard_vipps_swish_instabank/'
+        $pattern = '%s/branding/logos/visa_mastercard_vipps_swish_walley/'
             . 'variant/%s/colors/color/%s/width/%d/dintero_left_frame.svg';
 
         if ($this->scopeConfig->isSetFlag(self::XPATH_LOGO_TYPE)) {
-            $pattern = '%s/branding/logos/visa_mastercard_vipps_swish_instabank/'
+            $pattern = '%s/branding/logos/visa_mastercard_vipps_swish_walley/'
                 . 'variant/%s/color/%s/width/%d/dintero_left_frame.svg';
         }
 
@@ -416,12 +416,13 @@ class Config extends AbstractHelper
     public function getCheckoutLogoUrl($scopeCode = null)
     {
         $baseUrl = Client::CHECKOUT_API_BASE_URL;
-        $pattern = '%s/branding/profiles/%s/'
+        $pattern = '%s/branding/accounts/%s/profiles/%s/'
             . 'variant/%s/color/%s/width/%d/dintero_left_frame.svg';
 
         return sprintf(
             $pattern,
             $baseUrl,
+            $this->getFullAccountId($scopeCode),
             $this->getProfileId($scopeCode),
             $this->getLogoType(),
             str_replace('#', '', $this->getLogoColor()),

--- a/Model/Api/Client.php
+++ b/Model/Api/Client.php
@@ -253,7 +253,7 @@ class Client
             'Dintero-System-Name' => __('Magento'),
             'Dintero-System-Version' => $this->getSystemMeta()->getVersion(),
             'Dintero-System-Plugin-Name' => 'Dintero.Checkout.Magento.V2',
-            'Dintero-System-Plugin-Version' => '1.6.18',
+            'Dintero-System-Plugin-Version' => '1.6.20',
         ];
 
         if ($token && $token instanceof Token) {

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,5 @@
             "Dintero\\Checkout\\": ""
         }
     },
-    "version": "1.6.18"
+    "version": "1.6.20"
 }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Dintero_Checkout" setup_version="1.6.18">
+    <module name="Dintero_Checkout" setup_version="1.6.20">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Checkout"/>


### PR DESCRIPTION
Changing the branding url to new format to support named payment profiles

See https://docs.dintero.com/docs/checkout/checkout-branding for explanation of branding urls

Also: Changing default branding url to use `walley` instead of `instabank`

Not sure how we should version this, if we just merge it together with #57?
