### PR TITLE
Allow completing orders when transaction is at least captured

### DIFF
--- a/Gateway/Command/CaptureCommand.php
+++ b/Gateway/Command/CaptureCommand.php
@@ -68,7 +68,8 @@ class CaptureCommand implements CommandInterface
 
         $transactionInfo = $this->api->getTransaction($transactionId);
 
-        if (!empty($transactionInfo['status']) && $transactionInfo['status'] === Client::STATUS_CAPTURED) {
+        // If the transaction is in any post-capture state, we allow the completion of the order
+        if (!empty($transactionInfo['status']) && in_array($transactionInfo['status'], array(Client::STATUS_CAPTURED, Client::STATUS_PARTIALLY_CAPTURED, Client::STATUS_PARTIALLY_REFUNDED, Client::STATUS_REFUNDED, Client::STATUS_PARTIALLY_CAPTURED_REFUNDED))) {
             return $this;
         }
 

--- a/Model/Api/Client.php
+++ b/Model/Api/Client.php
@@ -11,7 +11,6 @@ use Magento\Framework\App\ProductMetadata;
 use Magento\Framework\DataObject;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Serialize\Serializer\Json;
-use Magento\Framework\Stdlib\DateTime\DateTime;
 use Magento\Payment\Gateway\Http\ClientException;
 use Magento\Payment\Gateway\Http\ConverterException;
 use Magento\Payment\Gateway\Http\TransferBuilderFactory;
@@ -61,8 +60,11 @@ class Client
     /*
      * Status partially captured
      */
-    const STATUS_PARTIALLY_CAPTURED = 'PARTIALLY_CAPTURED';
+   const STATUS_PARTIALLY_CAPTURED = 'PARTIALLY_CAPTURED';
 
+   const STATUS_PARTIALLY_REFUNDED = 'PARTIALLY_REFUNDED';
+   const STATUS_REFUNDED = 'REFUNDED';
+   const STATUS_PARTIALLY_CAPTURED_REFUNDED = 'PARTIALLY_CAPTURED_REFUNDED';
     /*
      * Standard
      */


### PR DESCRIPTION
Change the capture logic so that we allow completing the order whenever
the current status of the transaction is at least CAPTURED.

Referring to the [transaction state diagram](https://docs.dintero.com/docs/checkout/transaction-state-diagram/) for the states that should be allowed
